### PR TITLE
update dependencies for 0.86.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cfn-lint" %}
-{% set version = "0.86.0" %}
+{% set version = "0.86.1" %}
 
 package:
   name: {{ name|lower }}
@@ -25,23 +25,14 @@ requirements:
     - python
     - pyyaml <=5.2                  # [py==34]
     - pyyaml <=5.4                  # [py==35]
-    - pyyaml                        # [py!=34 or py!=35]
-    - networkx ~=2.4                # [py>=35]
-    - networkx <=2.2                # [py<35]
+    - pyyaml >5.4
     - networkx >=2.4,<4
-    - six >=1.11
     - aws-sam-translator >=1.86.0
-    - jsonpatch                     # [py!=34]
-    - jsonpatch  <=1.24             # [py==34]
+    - jsonpatch
     - jsonschema >=3.0,<5
-    - pathlib2 >=2.3.0              # [py<=34]
-    - importlib_resources ~=1.0.2   # [py==34]
-    - importlib_resources >=1.4,<4  # [py<37 and py!=34]
     - junit-xml ~=1.9
-    - pyrsistent <=0.16.0           # [py<35]
     - sympy >=1.0.0
     - regex >=2021.7.1
-    - typing_extensions >=4.9.0
     - sarif_om ~=1.0.4
     - jschema-to-python ~=1.2.3
     

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,22 +28,24 @@ requirements:
     - pyyaml                        # [py!=34 or py!=35]
     - networkx ~=2.4                # [py>=35]
     - networkx <=2.2                # [py<35]
+    - networkx>=2.4,<4
     - six >=1.11
-    - aws-sam-translator >=1.36.0
+    - aws-sam-translator >=1.86.0
     - jsonpatch                     # [py!=34]
     - jsonpatch  <=1.24             # [py==34]
-    - jsonschema ~=3.0
+    - jsonschema >=3.0,<5
     - setuptools
     - pathlib2 >=2.3.0              # [py<=34]
     - importlib_resources ~=1.0.2   # [py==34]
     - importlib_resources >=1.4,<4  # [py<37 and py!=34]
     - junit-xml ~=1.9
     - pyrsistent <=0.16.0           # [py<35]
-    - sympy >=1.12
-    - regex >=2023.10.3
+    - sympy>=1.0.0
+    - regex >=2021.7.1
     - typing_extensions >=4.9.0
-    - sarif_om >=1.0.4
-    - jschema-to-python >=1.2.3
+    - sarif_om ~=1.0.4
+    - jschema-to-python ~=1.2.3
+    
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ requirements:
     - jsonpatch                     # [py!=34]
     - jsonpatch  <=1.24             # [py==34]
     - jsonschema >=3.0,<5
-    - setuptools
     - pathlib2 >=2.3.0              # [py<=34]
     - importlib_resources ~=1.0.2   # [py==34]
     - importlib_resources >=1.4,<4  # [py<37 and py!=34]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - pyyaml                        # [py!=34 or py!=35]
     - networkx ~=2.4                # [py>=35]
     - networkx <=2.2                # [py<35]
-    - networkx>=2.4,<4
+    - networkx >=2.4,<4
     - six >=1.11
     - aws-sam-translator >=1.86.0
     - jsonpatch                     # [py!=34]
@@ -40,7 +40,7 @@ requirements:
     - importlib_resources >=1.4,<4  # [py<37 and py!=34]
     - junit-xml ~=1.9
     - pyrsistent <=0.16.0           # [py<35]
-    - sympy>=1.0.0
+    - sympy >=1.0.0
     - regex >=2021.7.1
     - typing_extensions >=4.9.0
     - sarif_om ~=1.0.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cfn-lint" %}
-{% set version = "0.52.0" %}
+{% set version = "0.86.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f26d30bfd6e8ef4f3563c9d3bc5499728eaf614b040563448d2063a2de730308
+  sha256: 7216e9c10dd27af73821d0ae79b17406cd89f5dfbc25feb5d2ba756eb6e9a651
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
   entry_points:
     - cfn-lint = cfnlint.__main__:main
 
@@ -39,6 +39,11 @@ requirements:
     - importlib_resources >=1.4,<4  # [py<37 and py!=34]
     - junit-xml ~=1.9
     - pyrsistent <=0.16.0           # [py<35]
+    - sympy >=1.12
+    - regex >=2023.10.3
+    - typing_extensions >=4.9.0
+    - sarif_om >=1.0.4
+    - jschema-to-python >=1.2.3
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ test:
 
 about:
   home: https://github.com/aws-cloudformation/cfn-python-lint
-  license: MIT No Attribution
+  license: MIT-0
   license_family: MIT
   license_file: LICENSE
   summary: 'CloudFormation Linter'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7216e9c10dd27af73821d0ae79b17406cd89f5dfbc25feb5d2ba756eb6e9a651
+  sha256: ed41e596d807fea2de74dbbfc0cb8b48f8787572c50e3b58cce05382a5af3a64
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,6 @@ requirements:
 test:
   requires:
     - pip
-    - junit-xml
-    - importlib_resources
   imports:
     - cfnlint
   commands:


### PR DESCRIPTION
cfn-lint 0.86.0

**Destination channel:** defaults

### Links

- [PKG-3626](https://anaconda.atlassian.net/browse/PKG-3626) 
- [Upstream repository](https://github.com/aws-cloudformation/cfn-lint)
- [Upstream changelog/diff](https://github.com/aws-cloudformation/cfn-lint/releases/tag/v0.86.0)

### Explanation of changes:

- Inclusion of new packages:  jschema-to-python, aws-sam-translator 1.86.0

[PKG-3626]: https://anaconda.atlassian.net/browse/PKG-3626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ