### PR TITLE
cfn-lint 1.37.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "cfn-lint" %}
-{% set version = "1.34.2" %}
+{% set version = "1.37.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/aws-cloudformation/cfn-lint/archive/refs/tags/v1.34.2.tar.gz
-  sha256: 501dcc2d8f0f04bb84108b54a31d2a3a59c08389c267404fef08502679324fff
+  url: https://github.com/aws-cloudformation/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 2d7285b2347f3fefd2445e09321a42d083957c1d2edaf496ccd242e2813ba389
 
 build:
   number: 0
@@ -20,37 +20,69 @@ requirements:
   host:
     - python
     - pip
-    - wheel
     - setuptools >=77.0.3
+    - wheel
   run:
     - python
     - pyyaml >5.4
-    - networkx >=2.4,<4
     - aws-sam-translator >=1.97.0
     - jsonpatch
-    - junit-xml ~=1.9
+    - networkx >=2.4,<4
     - sympy >=1.0.0
-    - regex >=2021.7.1
+    - regex
     - typing_extensions
   run_constrained:
-    - sarif_om ~=1.0.4
-    - jschema-to-python ~=1.2.3
+    - junit-xml >=1.9,<2
+    - jschema-to-python >=1.2.3,<1.3
+    - sarif-om >=1.0.4,<1.1
+
+# ModuleNotFoundError: No module named 'sarif_om'
+{% set tests_to_skip = "test_sarif_formatter" %}
+# subprocess.CalledProcessError: Command '['git', 'grep', '-l', 'id = "E0000"', 'src/cfnlint/rules/']' returned non-zero exit status 128.
+{% set tests_to_skip = tests_to_skip + " or test_update_docs" %}
 
 test:
+  source_files:
+    - test
+    - src/cfnlint/rules
   requires:
     - pip
+    - pytest
+    - defusedxml
+    - junit-xml
+    - pydot
   imports:
     - cfnlint
+    - cfnlint.api
+    - cfnlint.conditions
+    - cfnlint.config
+    - cfnlint.core
+    - cfnlint.data
+    - cfnlint.context
+    - cfnlint.decode
+    - cfnlint.exceptions
+    - cfnlint.formatters
+    - cfnlint.graph
+    - cfnlint.helpers
+    - cfnlint.jsonschema
+    - cfnlint.maintenance
+    - cfnlint.match
+    - cfnlint.rules
+    - cfnlint.runner
+    - cfnlint.schema
+    - cfnlint.template
   commands:
-    - cfn-lint -h
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -vv -x -k "not ({{ tests_to_skip }})" test
+    - cfn-lint -h
 
 about:
   home: https://github.com/aws-cloudformation/cfn-python-lint
   license: MIT-0
   license_family: MIT
   license_file: LICENSE
-  summary: 'CloudFormation Linter'
+  summary: CloudFormation Linter
   description: |
     Validate CloudFormation yaml/json templates against the
     CloudFormation spec and additional checks. Includes checking

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,7 +74,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -vv -x -k "not ({{ tests_to_skip }})" test
+    - pytest -v -k "not ({{ tests_to_skip }})" test
     - cfn-lint -h
 
 about:


### PR DESCRIPTION
cfn-lint 1.37.0 

**Destination channel:** Defaults

### Links

- [PKG-8366]
- dev_url:        https://github.com/aws-cloudformation/cfn-python-lint/tree/v1.37.0
- conda_forge:    https://github.com/conda-forge/cfn-lint-feedstock
- pypi:           https://pypi.org/project/cfn-lint/1.37.0
- pypi inspector: https://inspector.pypi.io/project/cfn-lint/1.37.0

### Explanation of changes:

- new version number


[PKG-8366]: https://anaconda.atlassian.net/browse/PKG-8366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ