### PR TITLE
cfn-lint 1.37.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,14 +25,14 @@ requirements:
   run:
     - python
     - pyyaml >5.4
-    - networkx >=2.4,<4
     - aws-sam-translator >=1.97.0
     - jsonpatch
-    - junit-xml ~=1.9
+    - networkx >=2.4,<4
     - sympy >=1.0.0
     - regex >=2021.7.1
     - typing_extensions
   run_constrained:
+    - junit-xml ~=1.9
     - sarif_om ~=1.0.4
     - jschema-to-python ~=1.2.3
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,15 +36,31 @@ requirements:
     - sarif_om ~=1.0.4
     - jschema-to-python ~=1.2.3
 
+{% set ignore_tests = "" %}
+# Test relies on being in a git repo folder.
+{% set ignore_tests = ignore_tests + " --deselect=test/unit/module/maintenance/test_update_documentation.py::TestUpdateDocumentation::test_update_docs" %}
+# [Optional] Skip long tests. Remove/comment-out to test all
+{% set ignore_tests = ignore_tests + " -m \"not data\"" %}
+
 test:
+  source_files:
+    - test
+    - src/cfnlint/rules  # Used by some tests
   requires:
     - pip
+    - pytest
+    - defusedxml
+    - pydot
+    - junit-xml ~=1.9
+    - sarif_om ~=1.0.4
+    - jschema-to-python ~=1.2.3
   imports:
     - cfnlint
   commands:
     - cfn-lint -h
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -vv {{ ignore_tests }} test
 
 about:
   home: https://github.com/aws-cloudformation/cfn-python-lint

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ test:
   commands:
     - cfn-lint -h
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
 
 about:
   home: https://github.com/aws-cloudformation/cfn-python-lint

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "cfn-lint" %}
-{% set version = "1.34.2" %}
+{% set version = "1.37.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/aws-cloudformation/cfn-lint/archive/refs/tags/v1.34.2.tar.gz
-  sha256: 501dcc2d8f0f04bb84108b54a31d2a3a59c08389c267404fef08502679324fff
+  url: https://github.com/aws-cloudformation/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 2d7285b2347f3fefd2445e09321a42d083957c1d2edaf496ccd242e2813ba389
 
 build:
   number: 0


### PR DESCRIPTION
cfn-lint 1.37.0 

**Destination channel:** Defaults

### Links

- [PKG-8366]
- dev_url:        https://github.com/aws-cloudformation/cfn-python-lint/tree/v1.37.0
- conda_forge:    https://github.com/conda-forge/cfn-lint-feedstock
- pypi:           https://pypi.org/project/cfn-lint/1.37.0
- pypi inspector: https://inspector.pypi.io/project/cfn-lint/1.37.0

### Explanation of changes:

- new version number
